### PR TITLE
fix: universal SDDL

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,7 +3,6 @@
   windows_subsystem = "windows"
 )]
 
-use std::fs::File;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::fs;
@@ -217,9 +216,9 @@ fn main() {
 					format!("[Interface]\nAddress = 10.0.0.0/24\nDNS = 1.1.1.1\nListenPort = 51820\nPrivateKey = {}", private_key)
 				);
 
-				// let mut perms = fs::metadata(format!("{}\\lib\\wg0.conf", &apath.display()))?.permissions();
-				// perms.set_readonly(false);
-				// fs::set_permissions(format!("{}\\lib\\wg0.conf", &apath.display()), perms)?;
+				let mut perms = fs::metadata(format!("{}\\lib\\wg0.conf", &apath.display()))?.permissions();
+				perms.set_readonly(false);
+				fs::set_permissions(format!("{}\\lib\\wg0.conf", &apath.display()), perms)?;
 
 				write_text_file(
 					&apath,
@@ -249,7 +248,8 @@ fn main() {
 					let service_perms = runas::Command::new("sc.exe")
 						.arg("sdset")
 						.arg("WireGuardTunnel$wg0") 
-						.arg("D:AR(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;RPWPDTRC;;;BU)S:AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)")
+						.arg("\"D:AR(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWRPWPDTLOCRRC;;;WD)(A;;CCLCSWLOCRRC;;;IU)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)\"")
+						// .arg("D:AR(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;RPWPDTRC;;;BU)S:AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)")
 						.status();
 
 					match service_perms {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "package": {
     "productName": "reseda",
-    "version": "0.1.0"
+    "version": "0.1.1"
   },
   "build": {
     "distDir": "../out",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,7 @@
     "bundle": {
       "active": true,
       "targets": "all",
-      "identifier": "com.tauri.dev",
+      "identifier": "com.reseda.release",
       "icon": [
         "icons/32x32.png",
         "icons/128x128.png",


### PR DESCRIPTION
Attempt to improve the SDDL which caused issues in clients unable to connect or disconnect the client.
This changes the SDDL string from:
```
D:AR(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;RPWPDTRC;;;BU)S:AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)
```
to the revised SDDL:
```
"D:AR(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWRPWPDTLOCRRC;;;WD)(A;;CCLCSWLOCRRC;;;IU)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)\"
```

The changes being:
`(A;;CCLCSWLOCRRC;;;IU)(A;;RPWPDTRC;;;BU)`
to
`(A;;CCLCSWRPWPDTLOCRRC;;;WD)(A;;CCLCSWLOCRRC;;;IU)`

Adding: `RPWPDT` (Up/Down/Interrupt) in an `everyone` group, removing the `BU` or `Built-in-users` group policy.

This patches issues preventing the windows service from being changed if the use/file lacked certain permissions, based on if the computer had the policies integrated or not / lacked certain permissions / domain set permissions / ....