### PR TITLE
feat: DNS routing instead of IP routing

### DIFF
--- a/src/components/tabview.tsx
+++ b/src/components/tabview.tsx
@@ -43,8 +43,10 @@ const TabView: NextPage<{ configuration: WireGuard, tab: "servers" | "settings" 
                                                     <p>{ e.country }</p>
                                                 </div>
                                                 
-                                                <p className={styles.mono}>{e.hostname}</p>
-                                                {
+                                                <div></div>
+                                                <div></div>
+                                                {/* <p className={styles.mono}>{e.hostname}</p> */}
+                                                {/* {
                                                     configuration.state.connection.server == e.id && configuration.state.connection.connection_type == 1 ?
                                                         <div className='flex flex-row items-center gap-4'>
                                                             <p className={styles.mono}>Connected</p>
@@ -54,7 +56,7 @@ const TabView: NextPage<{ configuration: WireGuard, tab: "servers" | "settings" 
                                                         <div className={styles.mono}>
                                                             Running for { moment.duration(new Date().getTime() - new Date(e.serverUp).getTime()).humanize() }
                                                         </div>
-                                                }
+                                                } */}
                                                 
                                                 
                                             </div>
@@ -188,7 +190,7 @@ const TabView: NextPage<{ configuration: WireGuard, tab: "servers" | "settings" 
                                     case 1:
                                         return (
                                             <div className="flex flex-col">
-                                                <p style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '1rem' }}>{ configuration.state.connection?.location?.country } <i className={styles.mono} style={{ opacity: 0.6 }}>{configuration.state.connection?.location?.id}</i>  </p>
+                                                <p style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '1rem' }}>{ configuration.state.connection?.location?.country }</p>
                                                 <h2 className="font-mono font-bold text-base">{connectionTime > 0 ? moment.utc(moment(today.getTime()).diff(moment(connectionTime))).format("HH:mm:ss") : "..."}</h2>
                                             </div>
                                         )
@@ -249,9 +251,9 @@ const TabView: NextPage<{ configuration: WireGuard, tab: "servers" | "settings" 
                             switch(configuration.state.connection?.connection_type) {
                                 case 0:
                                     return (
-                                        <Button style={{ flexGrow: 0, height: 'fit-content', width: '100%', backgroundColor: '#fff', padding: '.4rem 1rem', color: "#000", fontWeight: '600', fontFamily: "GT Walsheim Pro" }}  icon={false} onClick={() => {
+                                        <Button loaderOnly style={{ flexGrow: 0, height: 'fit-content', width: '100%', backgroundColor: '#fff', padding: '.4rem 1rem', color: "#000", fontWeight: '600', fontFamily: "GT Walsheim Pro" }}  icon={false} onClick={() => {
                                             configuration.disconnect();
-                                        }}>Connect to {"Singapore"}</Button>
+                                        }}></Button>
                                     )
                                 case 1:
                                     return (

--- a/src/reseda.ts
+++ b/src/reseda.ts
@@ -203,7 +203,7 @@ class WireGuard {
     
                     this.socket.close();
     
-                    await this.addPeer(message.server_public_key, message.endpoint, message.subdomain, callback_time);
+                    await this.addPeer(location, message.server_public_key, message.subdomain, callback_time);
     
                     this.setState({
                         connected: true,
@@ -251,11 +251,11 @@ class WireGuard {
             });
 
             this.config.wg = config;
-            const conn_ip = this.config.wg.peers?.[0]?.endpoint?.split(":")?.[0];
+            const conn_ip = this.config.wg.peers?.[0]?.endpoint?.split(":")?.[0]?.split(".")?.[0];
 
             if(!this?.user?.id || !this?.config?.keys?.public_key || !conn_ip) return;
             this.registry.forEach(e => {
-                if(e.hostname == conn_ip) {
+                if(e.id == conn_ip) {
                     this.setState({
                         connected: true,
                         connection_type: 1,
@@ -279,12 +279,12 @@ class WireGuard {
         });
     }
 
-    async addPeer(public_key: string, endpoint: string, subdomain: string, callback_time: Function) {
+    async addPeer(location: Server, public_key: string, subdomain: string, callback_time: Function) {
         // this.state.connected.endpoint = endpoint;
         this.config.wg.addPeer({
 			publicKey: public_key,
 			allowedIps: [ "0.0.0.0/0" ],
-			endpoint: endpoint
+			endpoint: `${location.id}.dns.reseda.app:51820`
 		});
 
         this.config.wg.wgInterface.address = [`10.8.${subdomain}/24`];


### PR DESCRIPTION
This PR includes the following features:
- Removes IP routing
- Adds DNS routing
- Adjusts UI to remove IP tracing

Here, we remove an initial prospective connection to a server from `122.122.122.122` (made up) to a reseda DNS address, with the following prefix, `<server>.dns.reseda.app`.